### PR TITLE
add if statement to only add ipv4 address

### DIFF
--- a/_modules/salt_cluster.py
+++ b/_modules/salt_cluster.py
@@ -67,7 +67,8 @@ def _get_ip_addr(driver, info, name):
         return salt.utils.to_str(info[name]['ipAddress'])
     elif driver == 'openstack':
         for ip_addr in info[name]['public_ips']:
-            return salt.utils.to_str(ip_addr)  # either v4 or v6
+            if salt.utils.network.is_ipv4(ip_addr):
+                return salt.utils.to_str(ip_addr)
 
 
 def _get_driver_creds(profile):


### PR DESCRIPTION
I kept running into issues when rackspace would grab the ipv6 address instead of ipv4 and since there is a bug with salt that salt-ssh does not work with ipv6 I added this so it would only grab the ipv4 address.

Let me know if you think this is a good approach or not
